### PR TITLE
Re-emit swim errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Events:
   to another peer, relevant keys `start`, `end`, `to`.
 * `'steal'`: when a part of the hashring is stolen by the current peer
   from another peer, relevant keys `start`, `end`, `from`.
+* `'error'`: when an error occurs in the [`swim`](https://github.com/mcollina/baseswim) instance.
 
 <a name="lookup"></a>
 ### instance.lookup(key)

--- a/hashring.js
+++ b/hashring.js
@@ -66,6 +66,9 @@ function Hashring (opts) {
     this._remove(meta)
     this.emit('peerDown', meta)
   })
+  this.swim.on('error', err => {
+    this.emit('error', err)
+  })
 }
 
 inherits(Hashring, EE)

--- a/test.js
+++ b/test.js
@@ -156,6 +156,20 @@ test('move event', { timeout: 5000 }, (t) => {
   })
 })
 
+test('error event', (t) => {
+  t.plan(2)
+
+  const peer = hashring({
+    joinTimeout: 10,
+    base: ['0.0.0.0:7799']
+  })
+  .on('error', err => {
+    t.ok(err instanceof Error)
+    t.equal(err.name, 'JoinFailedError')
+    peer.close()
+  })
+})
+
 test('client', (t) => {
   t.plan(4)
 


### PR DESCRIPTION
This allows us to listen for errors emitted by the swim library like `JoinFailedError`, etc.