### PR TITLE
Safe lookup

### DIFF
--- a/hashring.js
+++ b/hashring.js
@@ -210,7 +210,10 @@ Hashring.prototype.lookup = function (key) {
     index = 0
   }
 
-  return this._entries[index].peer
+  if (this._entries[index]) {
+    return this._entries[index].peer
+  }
+  return null
 }
 
 Hashring.prototype.next = function (key, prev) {
@@ -226,7 +229,9 @@ Hashring.prototype.next = function (key, prev) {
 
   prev = prev || []
 
-  let main = this.lookup(point).id
+  const peer = this.lookup(point)
+  if (peer === null) return null
+  let main = peer.id
 
   if (prev.indexOf(main) < 0) {
     prev.push(main)
@@ -259,7 +264,9 @@ Hashring.prototype.peers = function (myself) {
 }
 
 Hashring.prototype.allocatedToMe = function (key) {
-  return this.lookup(key).id === this.whoami()
+  const peer = this.lookup(key)
+  if (peer === null) return false
+  return peer.id === this.whoami()
 }
 
 Hashring.prototype.close = function (cb) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pre-commit": "^1.2.2",
     "standard": "^10.0.3",
     "steed": "^1.1.3",
-    "tap": "^10.7.2",
+    "tap": "^11.0.0",
     "xtend": "^4.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
In the case there are two nodes and one of them is a client node, if the not-client node goes down, the client node will throw an exception here:
https://github.com/upringjs/swim-hashring/blob/6d0a92dc958ce45b4623bad50afd761e72e8dfc9/hashring.js#L213

Because it's searching the key `peer` on and `undefined` object.
I'm having some trouble to test this, any suggestion?

Do we agree on the fix?